### PR TITLE
:bug: Fix Passing Record to Lookup fails API Call

### DIFF
--- a/src/main/java/com/zoho/crm/api/record/Record.java
+++ b/src/main/java/com/zoho/crm/api/record/Record.java
@@ -145,6 +145,18 @@ public class Record implements Model
 		 this.addKeyValue(field.getAPIName(), value);
 
 	}
+	
+	/**
+	* The method to add field value for Lookup Fields
+     	* @param field An instance of Field<Record>
+     	* @param value Record
+     	*/
+	public void addFieldValue(Field<Record> field, Record value) {
+		Record record = new Record();
+		record.setId(value.getId());
+		this.addKeyValue(field.getAPIName(), record);
+
+	}
 
 	/**
 	 * The method to add key value


### PR DESCRIPTION
When we pass a Record Originated for example from a SearchRecord to a Lookup Field for preparing another RecordOperation this ends in failing server-side with the Missing Mandatory Field Exception (maybe due by passing the entire record instead of the simple record with the ID)

Overriding the addFieldValue method and using the specific signature, creating a new instance of Record where to pass only the ID and pass the new record to the addKeyValue resolves the problem

@Aswin97 @raja-7453 